### PR TITLE
Add missing imports & article citation

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,3 +68,14 @@ top_level_module = TopLevelModule(
 ```python
 magnum = Magnum(bottom_level_module, top_level_module)
 ```
+
+## Citation
+
+```bibtex
+@article{alessandro2024modular,
+  title={A Modular End-to-End Multimodal Learning Method for Structured and Unstructured Data},
+  author={Alessandro, Marco D and Calabrés, Enrique and Elkano, Mikel},
+  journal={arXiv preprint arXiv:2403.04866},
+  year={2024}
+}
+```

--- a/models/mid_level_module.py
+++ b/models/mid_level_module.py
@@ -1,5 +1,7 @@
 import torch
 import torch.nn as nn
+import torch_cluster as tc
+import torch_geometric.nn as gnn
 from models.utils import get_batched_data
 
 class GraphPooling(nn.Module):


### PR DESCRIPTION
## Fixes

I've noticed that in the `mid_level_module.py` we missed to import the following packages:
- `import torch_cluster as tc`
- `import torch_geometric.nn as gnn`

I've also added the bibtex citation of the paper in the `README.md`.